### PR TITLE
add relative URL filter on the nav links

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -23,8 +23,8 @@
 
       <div id="banner">
         <nav id=“main-navigation”>
-          <a href="/" class="button">Directory of Resources</a>
-          <a href="/about/" class="button">About</a>
+          <a href="{{ "/" | relative_url }}" class="button">Directory of Resources</a>
+          <a href="{{ "/about/" | relative_url }}" class="button">About</a>
         </nav>
       </div>
         <!-- end banner -->


### PR DESCRIPTION
Chris take a look at my changes here on your nav links. This is the `relative_url` filter I was referring to. You should be able to merge this pull request into your master branch and see the updates. 

Let's address the other nav issues (disappearing on mobile) separately. It looks like a problem with the base templates that we can work through this week.